### PR TITLE
feat: same height on all cards

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -66,24 +66,24 @@
             <p class="lead">Acompanhe o impacto das nossas mentorias através das seguintes métricas:</p>
             <div class="row mt-4">
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body">
+                    <div class="card h-100">
+                        <div class="card-body d-flex flex-column justify-content-center">
                             <h5 class="card-title"><i class="fas fa-users"></i> Alunos</h5>
                             <p class="card-text">Quantidade de alunos: 100</p>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body">
+                    <div class="card h-100">
+                        <div class="card-body d-flex flex-column justify-content-center">
                             <h5 class="card-title"><i class="fas fa-check-circle"></i> Mentorias Realizadas</h5>
                             <p class="card-text">Quantidade de mentorias realizadas: 500</p>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body">
+                    <div class="card h-100">
+                        <div class="card-body d-flex flex-column justify-content-center">
                             <h5 class="card-title"><i class="fas fa-spinner"></i> Mentorias em Andamento</h5>
                             <p class="card-text">Quantidade de mentorias em andamento: 50</p>
                         </div>
@@ -161,7 +161,8 @@
             mode: 'carousel',
             controls: false,
             nav: false,
-            autoplay: true
+            autoplay: true,
+            autoplayButtonOutput: false,
         });
     </script>
 @endsection


### PR DESCRIPTION
**Summary**
Changes the height for all cards. Currently, on smaller screens, text wrapping results in more than one line and therefore causes a height difference between cards on the same row.

- **Issue:** none

**Changes**
- `resources/views/welcome.blade.php`: added `height: 100%` to the card and adjusted the card-body to center the text
- `resources/views/welcome.blade.php`: removed the autoplayButtonOutput from appearing on the carousel

**Images**

Before (full screen)
![image](https://github.com/DanielHe4rt/basement-mentorship/assets/48698836/fbef0d3f-d69f-423a-9aec-12b641737b82)

Before (mid screen)
![image](https://github.com/DanielHe4rt/basement-mentorship/assets/48698836/5ae1138c-4ce4-4b10-a67f-d2e6a1e373af)

After (full screen)
![image](https://github.com/DanielHe4rt/basement-mentorship/assets/48698836/6dc75bfb-750c-466f-9423-5daa8ca4eefd)

After (mid screen)
![image](https://github.com/DanielHe4rt/basement-mentorship/assets/48698836/6f0f9d77-f37e-4449-bf5d-4b23458a4b00)
